### PR TITLE
Add chart and filtering UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "next": "15.3.3",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.1"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #000000;
+  --foreground: #ffffff;
 }
 
 @theme inline {
@@ -10,13 +10,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,29 +3,52 @@
 
 import React, { useState } from 'react';
 import { QueryForm } from '../components/molecules/QueryForm';
+import { FilterControls } from '../components/molecules/FilterControls';
 import { PatientTable } from '../components/organisms/PatientTable';
+import { PatientChart } from '../components/organisms/PatientChart';
 import { QueryResponse } from '../lib/api';
 
 export default function HomePage() {
   const [data, setData] = useState<QueryResponse|null>(null);
+  const [minAge, setMinAge] = useState('');
+  const [condition, setCondition] = useState('');
+
+  const patients = data?.patients ?? [];
+  const filtered = patients.filter(p =>
+    (minAge ? p.age >= parseInt(minAge, 10) : true) &&
+    (condition ? p.condition === condition : true)
+  );
+  const conditions = Array.from(new Set(patients.map(p => p.condition)));
 
   return (
-    <main className="p-8 max-w-2xl mx-auto">
+    <main className="min-h-screen bg-black text-white flex flex-col items-center p-8">
       <h1 className="text-2xl font-bold mb-4">FHIR Patient Query</h1>
-      <QueryForm onResult={setData!} />
+      <div className="w-full max-w-md">
+        <QueryForm onResult={setData!} />
+      </div>
 
       {data && (
-        <>
+        <div className="text-green-400 w-full max-w-2xl">
           <section className="mt-6">
             <h2 className="font-semibold">FHIR Request</h2>
-            <pre className="bg-gray-100 p-2 rounded text-sm">{data.fhir_request}</pre>
+            <pre className="bg-gray-800 p-2 rounded text-sm overflow-auto">{data.fhir_request}</pre>
           </section>
+
+          <FilterControls
+            minAge={minAge}
+            setMinAge={setMinAge}
+            condition={condition}
+            setCondition={setCondition}
+            conditions={conditions}
+          />
+
+          <PatientChart patients={filtered} />
 
           <section>
             <h2 className="font-semibold mt-4">Results</h2>
-            <PatientTable patients={data.patients} />
+            <PatientTable patients={filtered} />
           </section>
-        </>
+        </div>
       )}
     </main>
   );

--- a/src/components/molecules/FilterControls.tsx
+++ b/src/components/molecules/FilterControls.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface Props {
+  minAge: string;
+  setMinAge: (a: string) => void;
+  condition: string;
+  setCondition: (c: string) => void;
+  conditions: string[];
+}
+
+export function FilterControls({ minAge, setMinAge, condition, setCondition, conditions }: Props) {
+  return (
+    <div className="flex space-x-2 mt-4">
+      <input
+        type="number"
+        placeholder="Min age"
+        value={minAge}
+        onChange={e => setMinAge(e.target.value)}
+        className="w-24 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-white"
+      />
+      <select
+        value={condition}
+        onChange={e => setCondition(e.target.value)}
+        className="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-white"
+      >
+        <option value="">All conditions</option>
+        {conditions.map(c => (
+          <option key={c} value={c}>{c}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/molecules/QueryForm.tsx
+++ b/src/components/molecules/QueryForm.tsx
@@ -11,6 +11,11 @@ interface Props {
 export function QueryForm({ onResult }: Props) {
   const [text, setText] = useState('');
   const [loading, setLoading] = useState(false);
+  const suggestions = [
+    'list diabetic patients',
+    'show me patients older than 50',
+    'patients with asthma',
+  ];
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -23,12 +28,18 @@ export function QueryForm({ onResult }: Props) {
   };
 
   return (
-    <form onSubmit={submit} className="space-x-2">
+    <form onSubmit={submit} className="space-x-2 flex justify-center">
       <TextInput
         value={text}
         onChange={e => setText(e.target.value)}
         placeholder="e.g. show me diabetic patients over 50"
+        list="query-suggestions"
       />
+      <datalist id="query-suggestions">
+        {suggestions.map(s => (
+          <option key={s} value={s} />
+        ))}
+      </datalist>
       <Button type="submit" disabled={loading}>
         {loading ? '…Fetching' : 'Submit'}
       </Button>

--- a/src/components/organisms/PatientChart.tsx
+++ b/src/components/organisms/PatientChart.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Pie } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Patient } from '../../lib/api';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+interface Props { patients: Patient[] }
+
+export function PatientChart({ patients }: Props) {
+  const counts: Record<string, number> = {};
+  for (const p of patients) {
+    counts[p.condition] = (counts[p.condition] || 0) + 1;
+  }
+  const labels = Object.keys(counts);
+  const data = {
+    labels,
+    datasets: [
+      {
+        data: labels.map(l => counts[l]),
+        backgroundColor: [
+          '#10B981',
+          '#3B82F6',
+          '#FBBF24',
+          '#F87171',
+          '#8B5CF6',
+        ],
+      },
+    ],
+  };
+
+  return (
+    <div className="mt-4 max-w-md w-full">
+      <Pie data={data} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow natural language suggestions
- add patient filter component
- visualize patient counts in a chart
- display results in green on black background

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d9b2fea08322a176909ae9e3631d